### PR TITLE
Resolve relative URLs (bugfix)

### DIFF
--- a/lib/microformats2/format.rb
+++ b/lib/microformats2/format.rb
@@ -40,9 +40,9 @@ module Microformats2
 
     def parse_implied_properties
       ip = []
-      ip << ImpliedProperty::Name.new(@element).parse unless property_present?(:name)
+      ip << ImpliedProperty::Name.new(@element, @base).parse unless property_present?(:name)
       ip << ImpliedProperty::Url.new(@element, @base).parse unless property_present?(:url)
-      ip << ImpliedProperty::Photo.new(@element).parse unless property_present?(:photo)
+      ip << ImpliedProperty::Photo.new(@element, @base).parse unless property_present?(:photo)
       ip.compact.each do |property|
         save_property_name(property.method_name)
         define_method(property.method_name)

--- a/lib/microformats2/implied_property/photo.rb
+++ b/lib/microformats2/implied_property/photo.rb
@@ -6,6 +6,10 @@ module Microformats2
         "photo"
       end
 
+      def to_s
+        @to_s = Microformats2::AbsoluteUri.new(@base, super.to_s).absolutize
+      end
+
       protected
 
       def name_map

--- a/lib/microformats2/property/foundation.rb
+++ b/lib/microformats2/property/foundation.rb
@@ -25,7 +25,7 @@ module Microformats2
       end
 
       def formats
-        @formats ||= format_classes.length >=1 ? FormatParser.parse(@element) : []
+        @formats ||= format_classes.length >=1 ? FormatParser.parse(@element, @base) : []
       end
 
       def to_hash

--- a/lib/microformats2/property/url.rb
+++ b/lib/microformats2/property/url.rb
@@ -15,7 +15,8 @@ module Microformats2
           "img" => "src",
           "object" => "data",
           "abbr" => "title",
-          "data" => "value" }
+          "data" => "value",
+          "input" => "value" }
       end
     end
   end


### PR DESCRIPTION
When the &lt;base> tag is used, the @base wasn't handed down all the way to URLs
and photos, this patch fixes this problem.

In addition to that it also makes it possible to handle u-url on <input> tags.

I hope this fixes some of the issues from the comments in https://github.com/G5/microformats2/issues/32 