### PR TITLE
Don't crash if it's not possible to attach to property

### DIFF
--- a/lib/microformats2/format.rb
+++ b/lib/microformats2/format.rb
@@ -102,7 +102,7 @@ module Microformats2
         send("#{mn}=", value)
       end
       if current = send(mn.pluralize)
-        current << value
+        current << value if current.respond_to? :<<
       else
         send("#{mn.pluralize}=", [value])
       end


### PR DESCRIPTION
Normally one can attach to properties, but if it is of a type URL then
it crashes hard. This check just drops everything which can't be
attached by `<<`.

Example which crashes it https://aaronparecki.com/2016/04/17/20/ 