### PR TITLE
While parsing check for existance of attribute

### DIFF
--- a/lib/microformats2/collection.rb
+++ b/lib/microformats2/collection.rb
@@ -103,7 +103,9 @@ module Microformats2
         else
           rel_values.each do |rel_value|
             @rels[rel_value] = [] unless @rels.has_key?(rel_value)
-            @rels[rel_value] << Microformats2::AbsoluteUri.new(@base, rel.attribute("href").text).absolutize
+            unless rel.attribute("href").nil?
+              @rels[rel_value] << Microformats2::AbsoluteUri.new(@base, rel.attribute("href").text).absolutize
+            end
           end
         end
       end


### PR DESCRIPTION
When parsing rel attributes, check for existance of the href attribute
before extracting the text, sometimes like in this post somewhere
https://www.patreon.com/posts/jeenas-excellent-6467133 it might be empty
and causes an exception. All the other uses above this one check that too.