### PR TITLE
Support `audio src=''` for u- properties

### DIFF
--- a/lib/microformats2/property/url.rb
+++ b/lib/microformats2/property/url.rb
@@ -12,6 +12,7 @@ module Microformats2
         @attr_map = {
           "a" => "href",
           "area" => "href",
+          "audio" => "src",
           "img" => "src",
           "object" => "data",
           "abbr" => "title",

--- a/lib/microformats2/property/url.rb
+++ b/lib/microformats2/property/url.rb
@@ -15,6 +15,8 @@ module Microformats2
           "audio" => "src",
           "img" => "src",
           "object" => "data",
+          "source" => "src",
+          "video" => "src",
           "abbr" => "title",
           "data" => "value",
           "input" => "value" }


### PR DESCRIPTION
I use this gem with Jekyll to pull reply contexts for my site. I often repost content from my podcast site where posts appear in an `h-feed` as `h-entry` with a `u-audio` on the `<audio />` tag inside of the `e-content`. (Here's an [example](https://wehavetoask.com/episodes/2017-01-31/)).

Before this patch, I would get back an empty `audio` property. With this patch, `audio` now contains the URL for the media file as I'd expect.